### PR TITLE
Use explicit boxing/unboxing of Integers and Booleans

### DIFF
--- a/src/main/java/org/mapyrus/Argument.java
+++ b/src/main/java/org/mapyrus/Argument.java
@@ -1230,7 +1230,7 @@ public class Argument implements Comparable<Argument>, Cloneable
 			else if (c == '\t')
 				sb.append("\\t");
 			else if (c > 127)
-				sb.append("\\u").append(String.format("%04X", c));
+				sb.append("\\u").append(String.format("%04X", Integer.valueOf(c)));
 			else
 				sb.append((char)c);
 		}

--- a/src/main/java/org/mapyrus/MapyrusServlet.java
+++ b/src/main/java/org/mapyrus/MapyrusServlet.java
@@ -126,7 +126,7 @@ public class MapyrusServlet extends HttpServlet
 			 * servlet init-param "io" is set.
 			 */
 			String s = getInitParameter("io");
-			boolean isIOAllowed = Boolean.valueOf(s);
+			boolean isIOAllowed = Boolean.valueOf(s).booleanValue();
 			throttle.setIOAllowed(isIOAllowed);
 			interpreter.setThrottle(throttle);
 			interpreter.interpret(context, f1, emptyStdin, null);

--- a/src/main/java/org/mapyrus/OutputFormat.java
+++ b/src/main/java/org/mapyrus/OutputFormat.java
@@ -1023,7 +1023,7 @@ public class OutputFormat
 		for (int i = 0; i < m_PDFContentGroupNames.size(); i++)
 		{
 			contentGroupsArray.append(" " + objectCounter + " 0 R");
-			int nestingLevel = m_PDFContentGroupNestingLevels.get(i);
+			int nestingLevel = m_PDFContentGroupNestingLevels.get(i).intValue();
 			if (i > 0)
 			{
 				if (nestingLevel > lastNestingLevel)
@@ -4622,7 +4622,7 @@ public class OutputFormat
 			 * know how many to remove later in the SVG file.
 			 */
 			Integer nStates = m_SVGOpenGTags.pop();
-			m_SVGOpenGTags.push(Integer.valueOf(nStates + 1));
+			m_SVGOpenGTags.push(Integer.valueOf(nStates.intValue() + 1));
 		}
 	}
 

--- a/src/main/java/org/mapyrus/script/MapyrusScriptContext.java
+++ b/src/main/java/org/mapyrus/script/MapyrusScriptContext.java
@@ -151,7 +151,7 @@ public class MapyrusScriptContext implements ScriptContext
 	public List<Integer> getScopes()
 	{
 		ArrayList<Integer> scopes = new ArrayList<Integer>();
-		scopes.add(ScriptContext.ENGINE_SCOPE);
+		scopes.add(Integer.valueOf(ScriptContext.ENGINE_SCOPE));
 		return scopes;
 	}
 


### PR DESCRIPTION
This avoids compiler warnings and avoids any problems with automatic boxing/unboxing.

Fixes #12